### PR TITLE
Feature: Getter method for basis vector as string

### DIFF
--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -351,7 +351,7 @@ class Circuit:
             elif (mag_real > 0 or (mag_real == 0 and mag_imag > 0)):
                 output += " + " + state_string
             # Negative real or negative imag w/o real
-            elif (mag_real < 0 or (mag_real == 0 and mag_imag > 0)):
+            elif (mag_real < 0 or (mag_real == 0 and mag_imag < 0)):
                 output += " - " + state_string
 
         return output

--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -3,7 +3,7 @@ import re
 
 class Circuit:
 
-    def __init__(self, qubits: int, operator_cache: bool = False, hardware_mode: str = 'CPU', DEBUG_syntax_validation: bool = True):
+    def __init__(self, qubits: int, operator_cache: bool = False, hardware_mode: str = 'CPU', DEBUG_syntax_validation: bool = True, output_rounding = 5):
         if qubits < 1:
             raise ValueError("Qubits parameter must be at least 1, got " + str(qubits))
 
@@ -27,6 +27,7 @@ class Circuit:
         self._circuit_state[0] = 1
         self._operator_cache_state = operator_cache
         self._operator_cache = {}
+        self._output_rounding = output_rounding
 
         # Gates
         self.IDENTITY = np.array([[1,0],[0,1]], dtype = complex)
@@ -323,8 +324,8 @@ class Circuit:
         for state in all_circuit_states:
             amplitude = self._circuit_state[state]
             # Separate real and imaginary parts
-            amp_real = np.real(amplitude)
-            amp_imag = np.imag(amplitude)
+            amp_real = np.round(np.real(amplitude), self._output_rounding)
+            amp_imag = np.round(np.imag(amplitude), self._output_rounding)
             state_string = ""
             # Add real part
             # If it is equal to 1, we don't add the real part

--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -296,6 +296,23 @@ class Circuit:
         collapsed_circuit_state = np.zeros(2 ** self._qubits, dtype = complex)
         collapsed_circuit_state[outcome] = 1 + 0j
         self._circuit_state = collapsed_circuit_state
+
+    
+    def get_state_as_string(self):
+        # currently an empty stub
+        return
+
+
+    def generate_bitstring(self, basis):
+        tracked_basis = basis
+        bitstring = ""
+        for i in range(self._qubits):
+            if (tracked_basis >= 2 ** (self._qubits - i - 1)):
+                bitstring = "1" + bitstring
+                tracked_basis -= 2 ** (self._qubits - i - 1)
+            else:
+                bitstring = "0" + bitstring
+        return bitstring
         
 
     def DEBUG_get_circuit_state(self):

--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -307,24 +307,17 @@ class Circuit:
             if (np.real(self._circuit_state[i]) != 0 or np.imag(self._circuit_state[i]) != 0):
                 all_circuit_states.append(i)
 
-        print(all_circuit_states)
-
         # Sort states by basis position
         sorted_all_circuit_states = []
-        for i in range(self._qubits):
-            step_size = 2 ** (self._qubits - i - 1)
-            index = 0
-            for j in range(int((self._qubits ** 2) / step_size)):
-                if index in sorted_all_circuit_states:
-                    index += step_size
-                elif index in all_circuit_states:
-                    sorted_all_circuit_states.append(index)
-                    index += step_size
+
+        for i in range(2 ** self._qubits):
+            target_bitstring = self.generate_bitstring(i)
+            for j in all_circuit_states:
+                if self.generate_bitstring(j) == target_bitstring:
+                    sorted_all_circuit_states.append(j)
 
         all_circuit_states = sorted_all_circuit_states
 
-        print(all_circuit_states)
- 
         ## Construct string of kets
         output = ""
         for state in all_circuit_states:
@@ -380,10 +373,10 @@ class Circuit:
         bitstring = ""
         for i in range(self._qubits):
             if basis >= 2 ** (self._qubits - i - 1):
-                bitstring = "1" + bitstring
+                bitstring += "1"
                 basis -= 2 ** (self._qubits - i - 1)
             else:
-                bitstring = "0" + bitstring
+                bitstring += "0"
         return bitstring
         
 

--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -341,6 +341,12 @@ class Circuit:
             # Positive imag and first iteration
             elif (output == "" and mag_real == 0 and mag_imag > 0):
                 output += state_string
+            # Negative real and first iteration
+            elif (output == "" and mag_real < 0):
+                output += "-" + state_string
+            # Negative imag and first iteration
+            elif (output == "" and mag_real == 0 and mag_imag < 0):
+                output += "-" + state_string
             # Positive real or positive imag w/o real
             elif (mag_real > 0 or (mag_real == 0 and mag_imag > 0)):
                 output += " + " + state_string

--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -308,6 +308,22 @@ class Circuit:
                 all_circuit_states.append(i)
 
         print(all_circuit_states)
+
+        # Sort states by basis position
+        sorted_all_circuit_states = []
+        for i in range(self._qubits):
+            step_size = 2 ** (self._qubits - i - 1)
+            index = 0
+            for j in range(int((self._qubits ** 2) / step_size)):
+                if index in sorted_all_circuit_states:
+                    index += step_size
+                elif index in all_circuit_states:
+                    sorted_all_circuit_states.append(index)
+                    index += step_size
+
+        all_circuit_states = sorted_all_circuit_states
+
+        print(all_circuit_states)
  
         ## Construct string of kets
         output = ""

--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -319,7 +319,7 @@ class Circuit:
                 state_string += str(np.abs(mag_real))
             # Add imaginary part
             if (mag_imag != 0):
-                # Sign in complex number
+                # If there's a real number, add the sign in the complex number
                 if (mag_real != 0 and mag_imag < 0):
                     state_string += "-"
                 elif (mag_real != 0 and mag_imag > 0):
@@ -331,8 +331,8 @@ class Circuit:
                 else:
                     state_string += str(np.abs(mag_imag)) + "i"
 
-            # Add ket
-            state_string += "|" + self.generate_bitstring(state) + ">"
+            # Add ket of state
+            state_string += "|" + self.generate_bitstring(state) + "⟩"
 
             ## Add state string to output
             # Positive real and first iteration

--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -300,70 +300,72 @@ class Circuit:
     
     def get_state_as_string(self):
         np = self.np
-        # Get list of all states with a non-zero magnitude
+        
+        ## Get list of all states with a non-zero amplitude
         all_circuit_states = []
         for i in range(2 ** self._qubits):
             if (np.real(self._circuit_state[i]) != 0 or np.imag(self._circuit_state[i]) != 0):
                 all_circuit_states.append(i)
+
+        print(all_circuit_states)
  
+        ## Construct string of kets
         output = ""
         for state in all_circuit_states:
-            magnitude = self._circuit_state[state]
+            amplitude = self._circuit_state[state]
             # Separate real and imaginary parts
-            mag_real = np.real(magnitude)
-            mag_imag = np.imag(magnitude)
+            amp_real = np.real(amplitude)
+            amp_imag = np.imag(amplitude)
             state_string = ""
             # Add real part
             # If it is equal to 1, we don't add the real part
-            if (mag_real != 0 and np.abs(mag_real) != 1):
-                state_string += str(np.abs(mag_real))
+            if amp_real != 0 and np.abs(amp_real) != 1:
+                state_string += str(np.abs(amp_real))
             # Add imaginary part
-            if (mag_imag != 0):
+            if amp_imag != 0:
                 # If there's a real number, add the sign in the complex number
-                if (mag_real != 0 and mag_imag < 0):
+                if amp_real != 0 and amp_imag < 0:
                     state_string += "-"
-                elif (mag_real != 0 and mag_imag > 0):
+                elif amp_real != 0 and amp_imag > 0:
                     state_string += "+"
 
-                # Simplify algebraically if mag_imag == 1
-                if (np.abs(mag_imag) == 1):
+                # Simplify algebraically if amp_imag == 1
+                if np.abs(amp_imag) == 1:
                     state_string += "i"
                 else:
-                    state_string += str(np.abs(mag_imag)) + "i"
+                    state_string += str(np.abs(amp_imag)) + "i"
 
             # Add ket of state
             state_string += "|" + self.generate_bitstring(state) + "⟩"
 
             ## Add state string to output
-            # Positive real and first iteration
-            if (output == "" and mag_real > 0):
-                output += state_string
-            # Positive imag and first iteration
-            elif (output == "" and mag_real == 0 and mag_imag > 0):
-                output += state_string
-            # Negative real and first iteration
-            elif (output == "" and mag_real < 0):
-                output += "-" + state_string
-            # Negative imag and first iteration
-            elif (output == "" and mag_real == 0 and mag_imag < 0):
-                output += "-" + state_string
-            # Positive real or positive imag w/o real
-            elif (mag_real > 0 or (mag_real == 0 and mag_imag > 0)):
-                output += " + " + state_string
-            # Negative real or negative imag w/o real
-            elif (mag_real < 0 or (mag_real == 0 and mag_imag < 0)):
-                output += " - " + state_string
+            # First iteration?
+            if output == "":
+                # Real part or imag part w/o real part is positive
+                if amp_real > 0 or (amp_real == 0 and amp_imag > 0):
+                    output += state_string
+                # Real part or imag part w/o real part is negative
+                elif amp_real < 0 or (amp_real == 0 and amp_imag < 0):
+                    output += "-" + state_string
+            
+            # Not first iteration, so add operands between kets
+            else:
+                # Real part or imag part w/o real part is positive
+                if amp_real > 0 or (amp_real == 0 and amp_imag > 0):
+                    output += " + " + state_string
+                # Real part or imag part w/o real part is negative
+                elif amp_real < 0 or (amp_real == 0 and amp_imag < 0):
+                    output += " - " + state_string
 
         return output
 
 
     def generate_bitstring(self, basis):
-        tracked_basis = basis
         bitstring = ""
         for i in range(self._qubits):
-            if (tracked_basis >= 2 ** (self._qubits - i - 1)):
+            if basis >= 2 ** (self._qubits - i - 1):
                 bitstring = "1" + bitstring
-                tracked_basis -= 2 ** (self._qubits - i - 1)
+                basis -= 2 ** (self._qubits - i - 1)
             else:
                 bitstring = "0" + bitstring
         return bitstring

--- a/quantum_circuit.py
+++ b/quantum_circuit.py
@@ -299,8 +299,56 @@ class Circuit:
 
     
     def get_state_as_string(self):
-        # currently an empty stub
-        return
+        np = self.np
+        # Get list of all states with a non-zero magnitude
+        all_circuit_states = []
+        for i in range(2 ** self._qubits):
+            if (np.real(self._circuit_state[i]) != 0 or np.imag(self._circuit_state[i]) != 0):
+                all_circuit_states.append(i)
+ 
+        output = ""
+        for state in all_circuit_states:
+            magnitude = self._circuit_state[state]
+            # Separate real and imaginary parts
+            mag_real = np.real(magnitude)
+            mag_imag = np.imag(magnitude)
+            state_string = ""
+            # Add real part
+            # If it is equal to 1, we don't add the real part
+            if (mag_real != 0 and np.abs(mag_real) != 1):
+                state_string += str(np.abs(mag_real))
+            # Add imaginary part
+            if (mag_imag != 0):
+                # Sign in complex number
+                if (mag_real != 0 and mag_imag < 0):
+                    state_string += "-"
+                elif (mag_real != 0 and mag_imag > 0):
+                    state_string += "+"
+
+                # Simplify algebraically if mag_imag == 1
+                if (np.abs(mag_imag) == 1):
+                    state_string += "i"
+                else:
+                    state_string += str(np.abs(mag_imag)) + "i"
+
+            # Add ket
+            state_string += "|" + self.generate_bitstring(state) + ">"
+
+            ## Add state string to output
+            # Positive real and first iteration
+            if (output == "" and mag_real > 0):
+                output += state_string
+            # Positive imag and first iteration
+            elif (output == "" and mag_real == 0 and mag_imag > 0):
+                output += state_string
+            # Positive real or positive imag w/o real
+            elif (mag_real > 0 or (mag_real == 0 and mag_imag > 0)):
+                output += " + " + state_string
+            # Negative real or negative imag w/o real
+            elif (mag_real < 0 or (mag_real == 0 and mag_imag > 0)):
+                output += " - " + state_string
+
+        return output
 
 
     def generate_bitstring(self, basis):

--- a/test_quantum_circuit.py
+++ b/test_quantum_circuit.py
@@ -4,7 +4,7 @@ from quantum_circuit import Circuit
 
 # For repeating tests, set the max qubits that the tests will repeat up until
 # A higher MAX_QUBITS value means more rigorous testing, but an increase in 1 results in double the memory usage and 8x testing time
-MAX_QUBITS = 12
+MAX_QUBITS = 8
 
 IDENTITY = np.array([[1,0],[0,1]], dtype = complex)
 PAULI_X = np.array([[0,1],[1,0]], dtype = complex)
@@ -320,3 +320,10 @@ class TestQuantumCircuit(unittest.TestCase):
                 if not (np.array_equal(outcome_ghz_0, state) or np.array_equal(outcome_ghz_1, state)):
                     self.fail(f"test_entanglement: Test failed with {i} qubits, circuit collapsed to a state which was not a GHZ state")
             print(f"test_entanglement: Test passed with {i} qubits")
+
+    def test_generate_bitstring(self):
+        for i in range(1, MAX_QUBITS + 1):
+            qubits = i
+            testCircuit = Circuit(qubits)
+            for j in range(2 ** qubits):
+                print(testCircuit.generate_bitstring(j))

--- a/test_quantum_circuit.py
+++ b/test_quantum_circuit.py
@@ -4,7 +4,7 @@ from quantum_circuit import Circuit
 
 # For repeating tests, set the max qubits that the tests will repeat up until
 # A higher MAX_QUBITS value means more rigorous testing, but an increase in 1 results in double the memory usage and 8x testing time
-MAX_QUBITS = 8
+MAX_QUBITS = 12
 
 IDENTITY = np.array([[1,0],[0,1]], dtype = complex)
 PAULI_X = np.array([[0,1],[1,0]], dtype = complex)
@@ -36,6 +36,13 @@ def generate_uniform_single_gate_circuit_DSL(gate: str, qubits: int):
         dsl += " " + gate + str(i)
     return dsl
 
+def convert_bitstring_to_decimal(bitstring):
+    decimal_value = 0
+    for i in range(len(bitstring)):
+        # If i'th wire in bitstring == "1" starting from the right side, then add 2^i to decimal_value
+        if bitstring[len(bitstring) - i - 1] == "1":
+            decimal_value += 2 ** i
+    return decimal_value
 
 class TestQuantumCircuit(unittest.TestCase):
 
@@ -326,4 +333,6 @@ class TestQuantumCircuit(unittest.TestCase):
             qubits = i
             testCircuit = Circuit(qubits)
             for j in range(2 ** qubits):
-                print(testCircuit.generate_bitstring(j))
+                converted_generated_bitstring = convert_bitstring_to_decimal(testCircuit.generate_bitstring(j))
+                self.assertEqual(j, converted_generated_bitstring, f"test_generate_bitstring: Test failed with {i} qubits, generate_bitstring() generated an incorrect bitstring. Expected {j}, received {converted_generated_bitstring}")
+            print(f"test_generate_bitstring: Test passed with {i} qubits")


### PR DESCRIPTION
Added two new methods into quantum_circuit:

- get_state_to_string(): Returns self._circuit_state as a formatted string, inclusive of signs & operands, superposition, amplitudes in the complex plane, etc
- generate_bitstring(): Dependency of get_state_to_string(), takes an int argument of the decimal value/basis and returns the corresponding bitstring

Added one new test in test_quantum_circuit:
- test_generate_bitstring(): Tests that all outputs of generate_bitstring() up to MAX_QUBITS are mathematically correct and convert successfully to their corresponding decimal representation